### PR TITLE
Keep fractions of seconds in timestamp

### DIFF
--- a/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdEmitter.cs
+++ b/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdEmitter.cs
@@ -22,10 +22,10 @@ namespace Serilog.Sinks.Fluentd
 
         public void Emit(DateTime timestamp, string tag, IDictionary<string, object> data)
         {
-            var unixTimestamp = timestamp.ToUniversalTime().Subtract(UnixEpoch).Ticks / 10000000;
+            var floatTimestamp = (double)timestamp.ToUniversalTime().Subtract(UnixEpoch).Ticks / 10000000;
             _packer.PackArrayHeader(3);
             _packer.PackString(tag, Encoding.UTF8);
-            _packer.Pack((ulong)unixTimestamp);
+            _packer.Pack(floatTimestamp);
             _packer.Pack(data, _serializationContext);
         }
     }


### PR DESCRIPTION
The problem which is fixed by this fix is following: the sink
truncates fractions of the seconds before sending log items to Fluentd.
Using "double" data type instead of "ulong" solves the problem.